### PR TITLE
Fix error "Unable to load source code" on [category]/[component]

### DIFF
--- a/src/lib/get-component-source.ts
+++ b/src/lib/get-component-source.ts
@@ -1,9 +1,7 @@
-import fs from 'fs/promises';
+import fs from 'fs';
 import path from 'path';
 
-export async function getComponentSource(
-  componentPath: string,
-): Promise<string> {
+export async function getComponentSource(componentPath: string): Promise<string> {
   const fullPath = path.join(
     process.cwd(),
     'src',
@@ -11,7 +9,7 @@ export async function getComponentSource(
     `${componentPath}.tsx`,
   );
   try {
-    const source = await fs.readFile(fullPath, 'utf-8');
+    const source = await fs.promises.readFile(fullPath, 'utf-8');
     return source;
   } catch (error) {
     console.error(`Error reading file ${fullPath}:`, error);


### PR DESCRIPTION
This bug its weird, its only showing on Production, where the source code wouldn't load

I changed `fs.readFile` to `fs.promises.readFile`, then build and run, and its working now

Feel free to check before merging